### PR TITLE
Update `rules` documentation in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ While it is not recommended, the `allow` list is an array of React hooks that wi
 {
   "plugins": ["@kyleshevlin"],
   "rules": [
-    "use-encapsulation/prefer-custom-hooks": [
+    "@kyleshevlin/prefer-custom-hooks": [
       "error",
       { "allow": ["useMemo"] }
     ]
@@ -173,7 +173,7 @@ On the other hand, the `block` list is an array of additional custom hooks that 
 {
   "plugins": ["@kyleshevlin"],
   "rules": [
-    "use-encapsulation/prefer-custom-hooks": [
+    "@kyleshevlin/prefer-custom-hooks": [
       "error",
       { "block": ["useMyCustomHook"] }
     ]


### PR DESCRIPTION
The eslint rule in readme was wrong, cf https://github.com/kyleshevlin/eslint-plugin-use-encapsulation/blob/2e5686486b88234a7e842a8bcfd7690382c51acd/docs/rules/prefer-custom-hooks.md