### PR TITLE
feat: add ESLint 9 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 node_modules/
+
+# Allow authors to have their own `settings.json` file without forcing it.
+.vscode
+
+# This could be generated with `yarn pack` for locally testing the package.
+*.tgz

--- a/README.md
+++ b/README.md
@@ -8,17 +8,7 @@ This rule does not allow using the hooks provided by the React library directly 
 
 ## Installation
 
-Install the plugin:
-
-```
-npm install --save-dev eslint-plugin-use-encapsulation
-```
-
-Or
-
-```
-yarn add -D eslint-plugin-use-encapsulation
-```
+Install the plugin: `npm install --save-dev eslint-plugin-use-encapsulation` or `yarn add -D eslint-plugin-use-encapsulation`.
 
 ## Configuration
 
@@ -30,16 +20,20 @@ import eslintPluginUseEncapsulation from 'eslint-plugin-use-encapsulation'
 export default [
   {
     plugins: {
-      'use-encapsulation': eslintPluginUseEncapsulation
+      'use-encapsulation': eslintPluginUseEncapsulation,
     },
     rules: {
-      'use-encapsulation/prefer-custom-hooks': 'error'
-    }
-  }
+      'use-encapsulation/prefer-custom-hooks': [
+        'error',
+        {
+          allow: ['useMemo'], // optional
+          block: ['useMyCustomHook'], // optional
+        },
+      ],
+    },
+  },
 ]
 ```
-
-**Note:** With ESLint 9's flat config, customizing the rule with options (e.g. `allow`) is currently not supported. 👀
 
 ### ESLint 8 (Legacy)
 
@@ -47,7 +41,13 @@ export default [
 {
   "plugins": ["use-encapsulation"],
   "rules": {
-    "use-encapsulation/prefer-custom-hooks": ["error"]
+    "use-encapsulation/prefer-custom-hooks": [
+      "error",
+      {
+        "allow": ["useMemo"], // optional
+        "block": ["useMyCustomHook"] // optional
+      }
+    ]
   }
 }
 ```
@@ -177,11 +177,9 @@ const MyComponent = () => { useMyCustomHook(); return null }
 
 ## Options
 
-**Note:** These options are only available in ESLint 8. See previous 📓 note about ESLint 9 flat config compatibility ☝️.
-
 There are two options for `prefer-custom-hooks`: an `allow` list, and a `block` list.
 
-#### `allow`
+### `allow`
 
 While it is not recommended, the `allow` list is an array of React hooks that will be exempted from triggering the rule. For example, you may want to allow `useMemo` to be used directly in components. You can set that up like so:
 
@@ -189,17 +187,14 @@ While it is not recommended, the `allow` list is an array of React hooks that wi
 {
   "plugins": ["use-encapsulation"],
   "rules": {
-    "use-encapsulation/prefer-custom-hooks": [
-      "error",
-      { "allow": ["useMemo"] }
-    ]
+    "use-encapsulation/prefer-custom-hooks": ["error", { "allow": ["useMemo"] }]
   }
 }
 ```
 
 It is recommended that you use the `allow` option sparingly. It is likely wiser to use the occasional `eslint-disable` than to allow a particular hook throughout your project.
 
-#### `block`
+### `block`
 
 On the other hand, the `block` list is an array of additional custom hooks that you would like to prevent from being used directly in a component. Perhaps you have a custom hook that really should be encapsulated with other hooks. Add it to the block list like so:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ yarn add -D eslint-plugin-use-encapsulation
 
 ## Configuration
 
+### ESLint 9 Flat Config
+
+```js
+import eslintPluginUseEncapsulation from 'eslint-plugin-use-encapsulation'
+
+export default [
+  {
+    plugins: {
+      'use-encapsulation': eslintPluginUseEncapsulation
+    },
+    rules: {
+      'use-encapsulation/prefer-custom-hooks': 'error'
+    }
+  }
+]
+```
+
+**Note:** With ESLint 9's flat config, customizing the rule with options (e.g. `allow`) is currently not supported. 👀
+
+### ESLint 8 (Legacy)
+
 ```json
 {
   "plugins": ["use-encapsulation"],
@@ -155,6 +176,8 @@ const MyComponent = () => { useMyCustomHook(); return null }
 ```
 
 ## Options
+
+**Note:** These options are only available in ESLint 8. See previous 📓 note about ESLint 9 flat config compatibility ☝️.
 
 There are two options for `prefer-custom-hooks`: an `allow` list, and a `block` list.
 

--- a/index.js
+++ b/index.js
@@ -4,4 +4,12 @@ module.exports = {
   rules: {
     'prefer-custom-hooks': preferCustomHooks,
   },
+  configs: {
+    recommended: {
+      plugins: ['use-encapsulation'],
+      rules: {
+        'use-encapsulation/prefer-custom-hooks': 'error',
+      },
+    },
+  },
 }

--- a/index.js
+++ b/index.js
@@ -4,12 +4,4 @@ module.exports = {
   rules: {
     'prefer-custom-hooks': preferCustomHooks,
   },
-  configs: {
-    recommended: {
-      plugins: ['use-encapsulation'],
-      rules: {
-        'use-encapsulation/prefer-custom-hooks': 'error',
-      },
-    },
-  },
 }

--- a/rules/prefer-custom-hooks.js
+++ b/rules/prefer-custom-hooks.js
@@ -23,9 +23,37 @@ const DEFAULT_OPTIONS = {
   allow: [],
 }
 
+const MESSAGE =
+  'Do not use React Hooks directly in a component. Abstract the functionality into a custom hook and use that instead.'
+
 module.exports = {
   meta: {
     type: 'suggestion',
+    docs: {
+      description: 'Enforce using React hooks only inside custom hooks',
+      recommended: 'error',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+          block: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noDirectHooks: MESSAGE,
+    },
   },
   create(context) {
     const userOptions = context.options[0] || {}
@@ -43,8 +71,7 @@ module.exports = {
           if (hookParent && !HOOK_PATTERN.test(hookParent.id.name)) {
             context.report({
               node,
-              message:
-                'Do not use React Hooks directly in a component. Abstract the functionality into a custom hook and use that instead.',
+              messageId: 'noDirectHooks',
             })
           }
         }


### PR DESCRIPTION
This PR adds ESLint 9 compatibility while maintaining ESLint 8 support. Changes include:

I've tested these changes with both ESLint 8 and 9 configurations in a real project.

Specifically, I used `yarn pack` and then did a local install in a separate project using that `.tgz`.

I tried first without any custom rules. Then, I added the `"allow"`. Upon running the linting in that other project, I observed that the linter complained about `useState`, but not about `useMemo`. This is the expected behavior.